### PR TITLE
Fix login session persistence

### DIFF
--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -18,6 +18,10 @@ export default function LoginPage() {
   const handleLogin = async () => {
     const res = await fetch("/api/auth/login", {
       method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      credentials: "include",
       body: JSON.stringify(formData),
     });
 


### PR DESCRIPTION
## Summary
- ensure login fetch includes credentials and content-type header so session cookie persists

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68988e6b7924832dba8419b341c16581